### PR TITLE
docs: add magicblock skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ AI coding skills that enhance developer productivity on Solana.
 
 - [solana-dev-skill](https://github.com/solana-foundation/solana-dev-skill) - End-to-end Solana development skill for Claude Code. Covers wallet connections, Anchor/Pinocchio programs, client generation, testing with LiteSVM/Mollusk, and security best practices.
 
+- [magicblock-dev-skill](https://github.com/magicblock-labs/magicblock-dev-skill) - End-to-end MagicBlock development skill for Claude Code. [MagicBlock](https://magicblock.xyz) is a Solana network extension designed to help programs with latency/privacy needs, along with other native tools like VRFs, Cranks, Session Keys and more.
+
 ## AI Agents
 
 AI agents and autonomous systems built for Solana.


### PR DESCRIPTION
Adding a MagicBlock Claude skill. MagicBlock is a Solana network extension, allowing Solana developers to temporarily access low latency state changes. 