### PR TITLE
docs: add SATI (Solana Agent Trust Infrastructure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ AI-enhanced development tools for the Solana ecosystem.
 
 - [SLO (Solana LLM Oracle)](https://github.com/GauravBurande/solana-llm-oracle) - Enables LLM inference directly in Solana programs for on-chain AI capabilities in games and protocols requiring autonomous functions.
 - [LumoKit](https://github.com/Lumo-Labs-AI/lumokit) - Lightweight Python AI toolkit for Solana with on-chain actions, token swaps via Jupiter, and research capabilities for ecosystem developers.
+- [SATI (Solana Agent Trust Infrastructure)](https://github.com/cascade-protocol/sati) - ERC-8004 compliant agent identity and reputation with proof-of-participation: agents sign before knowing feedback outcomes.
 
 ## Learning Resources
 


### PR DESCRIPTION
## Summary

Adding SATI (Solana Agent Trust Infrastructure) to the Developer Tools section.

SATI is ERC-8004 compliant trust infrastructure for AI agents on Solana, featuring:
- **Agent Identity**: Token-2022 NFTs with cross-chain support (CAIP-10, DIDs)
- **Reputation System**: Feedback and validation schemas with ZK-compressed storage
- **Proof-of-Participation**: Agents sign before knowing feedback outcomes, preventing selective participation in reputation

**Program ID**: `satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe`

**Links**:
- Repository: https://github.com/cascade-protocol/sati
- Documentation: https://sati.cascade.fyi
- SDK: `@cascade-fyi/sati-sdk`