### PR TITLE
docs: add Solana Mobile DeFi Agent to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ AI agents and autonomous systems built for Solana.
 - [Eliza Framework](https://github.com/elizaOS/eliza) - Lightweight TypeScript AI agent framework with Solana integrations, Twitter/X bots, and character-based configuration for agent behaviors.
 - [GOAT Framework](https://github.com/goat-sdk/goat) - Open-source toolkit for connecting AI agents to 200+ onchain tools with multi-chain support including Solana, EVM, and more.
 - [AgenC](https://github.com/tetsuo-ai/AgenC) - Privacy-focused multi-agent coordination framework with ZK proof integrations and confidential compute for Solana.
+- [Solana Mobile DeFi Agent](https://github.com/Von-Labs/solana-mobile-defi-agent) - Full-stack React Native AI DeFi agent for Solana using LLMs (Claude, GPT, Gemini) with Jupiter MCP Tools for chat-driven swaps, price checks, portfolio views, and automated trading.
 
 ## Developer Tools
 


### PR DESCRIPTION
## Summary
- Add Solana Mobile DeFi Agent to the `AI Agents` section.
- Highlight LLM support (Claude, GPT, Gemini) and Jupiter MCP Tools integration.
- Describe the stack: React Native (Expo) mobile client with a Node.js/Express TypeScript backend.