### PR TITLE
Add Jupiter agent skill to DeFi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ AI coding skills that enhance developer productivity on Solana.
 
 ### DeFi
 
+- [jupiter-skill](https://github.com/jup-ag/agent-skills/tree/main/skills/integrating-jupiter) - AI coding skill for Jupiter covering Ultra swaps, limit orders, DCA, perpetuals, lending, and token APIs on Solana.
 - [drift-skill](https://github.com/sendaifun/skills/tree/main/skills/drift) - AI coding skill for Drift Protocol SDK covering perpetual futures, spot trading, and DeFi applications on Solana.
 - [kamino-skill](https://github.com/sendaifun/skills/tree/main/skills/kamino) - AI coding skill for Kamino Finance covering lending, borrowing, liquidity management, leverage trading, and oracle aggregation on Solana.
 - [lulo-skill](https://github.com/sendaifun/skills/tree/main/skills/lulo) - AI coding skill for Lulo, Solana's lending aggregator that routes deposits to the highest-yielding protocols across Kamino, Drift, MarginFi, and Jupiter.


### PR DESCRIPTION
## Summary
- Adds [jupiter-skill](https://github.com/jup-ag/agent-skills/tree/main/skills/integrating-jupiter) to the DeFi AI Coding Skills section
- Jupiter's agent skill covers Ultra swaps, limit orders, DCA, perpetuals, lending, and token APIs on Solana

## Test plan
- [x] Entry follows the required format: `[name](link) - Brief description.`
- [x] Placed in the appropriate category (DeFi)
- [x] Link points to the correct skill directory