### PR TITLE
Add DaybreakScan — Solana deployer reputation engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ AI-enhanced development tools for the Solana ecosystem.
 - [vulnhunter-skill](https://github.com/sendaifun/skills/tree/main/skills/vulnhunter) - AI coding skill for security vulnerability detection, dangerous API hunting, and variant analysis across Solana codebases.
 - [code-recon-skill](https://github.com/sendaifun/skills/tree/main/skills/zz-code-recon) - AI coding skill for deep architectural context building for security audits, mapping trust boundaries and vulnerability analysis.
 - [surfpool-skill](https://github.com/sendaifun/skills/tree/main/skills/surfpool) - AI coding skill for Surfpool, a Solana development environment with mainnet forking, cheatcodes, and Infrastructure as Code.
+- [DaybreakScan](https://github.com/Jpatching/daybreak) - Solana deployer reputation engine with MCP server and x402-gated API, enabling AI agents to score token deployers by death rate, cluster analysis, and on-chain behavioral signals.
 
 ## Learning Resources
 


### PR DESCRIPTION
## Summary

Adds [DaybreakScan](https://github.com/Jpatching/daybreak) to the **Developer Tools** section.

DaybreakScan is a Solana deployer reputation engine that scores token deployers based on on-chain behavioral signals. It provides three integration paths for AI agents and developers:

- **MCP Server** — Stdio JSON-RPC server with `daybreak_scan_deployer` and `daybreak_scan_wallet` tools, pluggable into Claude Code, Cursor, and any MCP-compatible agent
- **REST API** — Authenticated endpoints for deployer scans, with x402 payment-gated access for high-volume usage
- **Report Cards** — Auto-generated PNG report cards for social sharing and bot integrations

### What it analyzes
- Deployer death rate (% of dead tokens across full history)
- Funding cluster analysis (traces shared funding sources across deployer wallets)
- Token-level risks: mint/freeze authority, bundle detection, top holder concentration
- Deploy velocity, deployer holdings, and behavioral patterns
- Reputation scoring (0-100) with CLEAN / SUSPICIOUS / SERIAL_RUGGER verdicts

### Links
- GitHub: https://github.com/Jpatching/daybreak
- Live scanner: https://www.daybreakscan.com
- API docs: https://www.daybreakscan.com/docs