### PR TITLE
Add octav-api-skill to DeFi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ AI coding skills that enhance developer productivity on Solana.
 - [sanctum-skill](https://github.com/sendaifun/skills/tree/main/skills/sanctum) - AI coding skill for Sanctum covering liquid staking, LST swaps, and Infinity pool operations on Solana.
 - [dflow-skill](https://github.com/sendaifun/skills/tree/main/skills/dflow) - AI coding skill for DFlow trading protocol covering spot trading, prediction markets, Swap API, and WebSocket streaming on Solana.
 - [ranger-finance-skill](https://github.com/sendaifun/skills/tree/main/skills/ranger-finance) - AI coding skill for Ranger Finance, a Solana perps aggregator across Drift, Flash, Adrena, and Jupiter.
+- [octav-api-skill](https://github.com/Octav-Labs/octav-api-skill) - AI coding skill for Octav API covering Solana wallet portfolio tracking, transaction history, DeFi protocol positions, and token analytics.
 
 ### Infrastructure
 


### PR DESCRIPTION
## Description

Adds [octav-api-skill](https://github.com/Octav-Labs/octav-api-skill) to the DeFi section.

The Octav API skill enables AI agents to interact with Octav's API for Solana wallet portfolio tracking, transaction history, DeFi protocol positions, and token analytics.

## Checklist

- [x] Link points to the official GitHub repository
- [x] Description follows the existing format
- [x] Added to the correct section (DeFi)