### PR TITLE
Add SP3ND Agent Skill — autonomous Amazon purchases with USDC on Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ AI agents and autonomous systems built for Solana.
 - [GOAT Framework](https://github.com/goat-sdk/goat) - Open-source toolkit for connecting AI agents to 200+ onchain tools with multi-chain support including Solana, EVM, and more.
 - [AgenC](https://github.com/tetsuo-ai/AgenC) - Privacy-focused multi-agent coordination framework with ZK proof integrations and confidential compute for Solana.
 - [Breeze Agent Kit](https://github.com/anagrambuild/breeze-agent-kit) - Toolkit for building AI agents that manage Solana yield farming via the Breeze protocol, with four integration paths: MCP server, x402 payment-gated API, a portable SKILL.md for agent frameworks, and one-command install through ClawHub.
+- [SP3ND Agent Skill](https://github.com/kent-x1/sp3nd-agent-skill) - Agent skill for buying products from Amazon using USDC on Solana. Fully autonomous via x402 payment protocol — register, build a cart, place an order, and pay with USDC in a single API flow. 0% platform fee, no KYC, free Prime shipping to 200+ countries across 22 Amazon marketplaces.
 
 ## Developer Tools
 


### PR DESCRIPTION
## Description

Adds [SP3ND Agent Skill](https://github.com/kent-x1/sp3nd-agent-skill) to the AI Agents section.

SP3ND is an agent skill that lets AI agents autonomously buy products from Amazon using USDC on Solana via the x402 payment protocol.

**Key features:**
- 0% platform fee
- No KYC required
- 200+ countries, 22 Amazon marketplaces
- Free Prime shipping on eligible items
- Fully autonomous via x402 HTTP payment protocol
- USDC on Solana (400ms finality)

**Available at:**
- GitHub: https://github.com/kent-x1/sp3nd-agent-skill
- Skill file: https://sp3nd.shop/skill.md
- ClawHub: https://clawhub.ai/kent-x1/sp3nd

**End-to-end tested:** registerAgent → cart → order → x402 pay → Helius webhook → Paid.

## Checklist
- [x] Link is accessible
- [x] Open source (Apache 2.0)
- [x] Description follows existing format
- [x] Added to correct section (AI Agents)