### PR TITLE
Add SocAI category and hey.lol

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [DeFi](#defi)
   - [Infrastructure](#infrastructure)
 - [AI Agents](#ai-agents)
+- [SocAI](#socai)
 - [Developer Tools](#developer-tools)
 - [Learning Resources](#learning-resources)
 - [Contributing](#contributing)
@@ -65,6 +66,12 @@ AI agents and autonomous systems built for Solana.
 - [AgenC](https://github.com/tetsuo-ai/AgenC) - Privacy-focused multi-agent coordination framework with ZK proof integrations and confidential compute for Solana.
 - [Breeze Agent Kit](https://github.com/anagrambuild/breeze-agent-kit) - Toolkit for building AI agents that manage Solana yield farming via the Breeze protocol, with four integration paths: MCP server, x402 payment-gated API, a portable SKILL.md for agent frameworks, and one-command install through ClawHub.
 - [SP3ND Agent Skill](https://github.com/kent-x1/sp3nd-agent-skill) - Agent skill for buying products from Amazon using USDC on Solana. Fully autonomous via x402 payment protocol — register, build a cart, place an order, and pay with USDC in a single API flow. 0% platform fee, no KYC, free Prime shipping to 200+ countries across 22 Amazon marketplaces.
+
+## SocAI
+
+Agent-native social platforms where AI agents are first-class users alongside humans.
+
+- [hey.lol](https://hey.lol) - Agent-friendly social platform with content monetization enabled via x402. Agents can register, post, engage, transact, grow, and learn autonomously.
 
 ## Developer Tools
 


### PR DESCRIPTION
## Summary
- Adds a new **SocAI** category to the list
- Adds [hey.lol](https://hey.lol) as the first entry under SocAI

## Why a new category?
Existing categories cover dev tools, coding skills, and agent frameworks/toolkits. But there's an emerging class of platforms that are social-first — where AI agents are first-class users who can register, post, engage, and transact alongside humans. This doesn't fit under "AI Agents" (which covers SDKs and frameworks for building agents) or "Developer Tools." **SocAI** (Social AI) captures this new category of agent-native social platforms.

## Entry added
`[hey.lol](https://hey.lol) - Agent-friendly social platform with content monetization enabled via x402. Agents can register, post, engage, transact, grow, and learn autonomously.`