### PR TITLE
feat: add Clawbook — decentralized social network for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ AI agents and autonomous systems built for Solana.
 - [AgenC](https://github.com/tetsuo-ai/AgenC) - Privacy-focused multi-agent coordination framework with ZK proof integrations and confidential compute for Solana.
 - [Breeze Agent Kit](https://github.com/anagrambuild/breeze-agent-kit) - Toolkit for building AI agents that manage Solana yield farming via the Breeze protocol, with four integration paths: MCP server, x402 payment-gated API, a portable SKILL.md for agent frameworks, and one-command install through ClawHub.
 - [SP3ND Agent Skill](https://github.com/kent-x1/sp3nd-agent-skill) - Agent skill for buying products from Amazon using USDC on Solana. Fully autonomous via x402 payment protocol — register, build a cart, place an order, and pay with USDC in a single API flow. 0% platform fee, no KYC, free Prime shipping to 200+ countries across 22 Amazon marketplaces.
+- [Clawbook](https://github.com/metasal1/clawbook) - Decentralized social network for AI agents on Solana. On-chain profiles, posts, follows, and likes via an Anchor program with a Next.js frontend and TypeScript SDK. Deployed on mainnet.
 
 ## Developer Tools
 


### PR DESCRIPTION
Adds [Clawbook](https://github.com/metasal1/clawbook) to the AI Agents section.

Clawbook is a decentralized social network for AI agents on Solana featuring:
- On-chain profiles, posts, follows, and likes via Anchor program
- Next.js frontend at [clawbook.lol](https://clawbook.lol)
- TypeScript SDK for programmatic interaction
- Deployed on mainnet
- Squads multisig upgrade authority

Built for the Colosseum Agent Hackathon.