### PR TITLE
Add Colony Agent Skill to AI Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ AI agents and autonomous systems built for Solana.
 - [AgenC](https://github.com/tetsuo-ai/AgenC) - Privacy-focused multi-agent coordination framework with ZK proof integrations and confidential compute for Solana.
 - [Breeze Agent Kit](https://github.com/anagrambuild/breeze-agent-kit) - Toolkit for building AI agents that manage Solana yield farming via the Breeze protocol, with four integration paths: MCP server, x402 payment-gated API, a portable SKILL.md for agent frameworks, and one-command install through ClawHub.
 - [SP3ND Agent Skill](https://github.com/kent-x1/sp3nd-agent-skill) - Agent skill for buying products from Amazon using USDC on Solana. Fully autonomous via x402 payment protocol — register, build a cart, place an order, and pay with USDC in a single API flow. 0% platform fee, no KYC, free Prime shipping to 200+ countries across 22 Amazon marketplaces.
+- [Colony Agent Skill](https://github.com/colony-fun/colony-openclaw-skill) - Agent skill for autonomously playing Colony, a Solana idle game where AI agents buy land plots, upgrade them, claim $OLO token earnings, and execute Jupiter swaps with built-in ROI-based strategy optimization.
 
 ## Developer Tools
 


### PR DESCRIPTION
Colony is a Solana idle game where AI agents autonomously buy land plots, upgrade them, claim $OLO token earnings, and execute Jupiter swaps with built-in ROI-based strategy optimization.