### PR TITLE
Add Loyal to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ AI-enhanced development tools for the Solana ecosystem.
 - [Quicknode RPC via x402](https://www.quicknode.com/docs/build-with-ai/x402-payments) - Pay-per-request access to Solana endpoints using the x402 payment protocol. No signup, no API keys — pay with USDC on Solana and make calls to Solana autonomously. Includes a [reference implementation](https://github.com/quiknode-labs/qn-x402-examples).
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs - auto-pays HTTP 402 responses with USDC on Solana and Base, with MCP stdio proxy for AI agents (`npx x402-proxy`).
 - [Unbrowse](https://github.com/unbrowse-ai/unbrowse) - Agent browser that auto-discovers API endpoints from any website and publishes reusable skills to a shared marketplace. Ships with pre-learned skills for Solana DeFi protocols (Jupiter, Raydium, etc.) and x402-enabled for autonomous USDC payments on Solana.
+- [Loyal](https://github.com/loyal-labs/loyal-app) - Open-source Solana wallet with smart-account guardrails for AI agents: spending caps, token whitelists, and approved protocols enforced at the smart-account layer.
 
 ## Learning Resources
 


### PR DESCRIPTION
## Add Loyal to Developer Tools

[Loyal](https://github.com/loyal-labs/loyal-app) is an open-source Solana wallet with smart-account guardrails that gives AI agents on-chain limits: spending caps, token whitelists, and approved protocols enforced at the smart-account layer, so an agent can only act inside the limits a user sets.

- **GitHub:** https://github.com/loyal-labs/loyal-app
- **Category:** Developer Tools
- **Live surfaces:** web app, Chrome extension, Telegram mini app, Android, and Seeker (Solana Mobile)
- **Docs:** https://docs.askloyal.com

(Rebased onto current `main` to resolve the prior merge conflict and updated the description to current positioning.)
