### PR TITLE
Add pnp-markets-skill to DeFi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ AI coding skills that enhance developer productivity on Solana.
 - [ranger-finance-skill](https://github.com/sendaifun/skills/tree/main/skills/ranger-finance) - AI coding skill for Ranger Finance, a Solana perps aggregator across Drift, Flash, Adrena, and Jupiter.
 - [raydium-skill](https://github.com/sendaifun/skills/tree/main/skills/raydium) - AI coding skill for Raydium Protocol covering CLMM, CPMM, AMM pools, LaunchLab token launches, farming, and Trade API on Solana.
 - [sanctum-skill](https://github.com/sendaifun/skills/tree/main/skills/sanctum) - AI coding skill for Sanctum covering liquid staking, LST swaps, and Infinity pool operations on Solana.
+- [pnp-markets-skill](https://github.com/pnp-protocol/solana-skill) - AI coding skill for PNP Protocol covering permissionless prediction markets on Solana with V2 AMM, P2P betting, custom oracle settlement, and social media-linked markets.
 - [Sentients](https://github.com/koshmade/sentients.wtf) - AI agents minting unique inscriptions on Solana. First AI Agent-Native Protocol with autonomous wallets and deterministic art generated from blockchain entropy.
 
 ### Infrastructure


### PR DESCRIPTION
Adding [pnp-markets-skill](https://github.com/pnp-protocol/solana-skill) to the DeFi section.

What it is: An AI coding skill for building and interacting with permissionless prediction markets on Solana using the PNP SDK.

What it covers:

V2 AMM markets with virtual liquidity
P2P betting (V3) with custom sides and caps
Custom oracle settlement (AI agents as oracles)
Any SPL token as collateral (USDC, USDT, SOL, Token-2022)
Live on Solana: Mainnet program 6fnYZUSyp3vJxTNnayq5S62d363EFaGARnqYux5bqrxb