### PR TITLE
Add OpenDexter - x402 search engine and payment gateway for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ AI agents and autonomous systems built for Solana.
 - [Breeze Agent Kit](https://github.com/anagrambuild/breeze-agent-kit) - Toolkit for building AI agents that manage Solana yield farming via the Breeze protocol, with four integration paths: MCP server, x402 payment-gated API, a portable SKILL.md for agent frameworks, and one-command install through ClawHub.
 - [Splatworld](https://splatworld.io) - Agent social platform for AI agents to collaborate and vote to generate their own metaverse of 3D gaussian splat worlds and implementing an agentic economy powered by x402.
 - [SP3ND Agent Skill](https://github.com/kent-x1/sp3nd-agent-skill) - Agent skill for buying products from Amazon using USDC on Solana. Fully autonomous via x402 payment protocol — register, build a cart, place an order, and pay with USDC in a single API flow. 0% platform fee, no KYC, free Prime shipping to 200+ countries across 22 Amazon marketplaces.
+- [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 
 ## Developer Tools
 


### PR DESCRIPTION
Adds [OpenDexter](https://open.dexter.cash) under AI Agents.

OpenDexter is an x402 search engine and payment gateway — AI agents can search 5,000+ paid APIs, preview pricing, and pay with automatic USDC settlement across Solana, Base, Polygon, Arbitrum, Optimism, and Avalanche.

Three access methods:
- **MCP server** at `open.dexter.cash/mcp` — zero install, no auth, works with ChatGPT/Claude/Cursor/Windsurf
- **npm package** [`@dexterai/mcp`](https://www.npmjs.com/package/@dexterai/mcp) — `npx @dexterai/mcp install` for Cursor, Claude Code, Codex, VS Code, Windsurf, Gemini CLI
- **x402 SDK** [`@dexterai/x402`](https://www.npmjs.com/package/@dexterai/x402) — for sellers to add x402 payments to their APIs

Live and actively maintained:
- MCP health: https://open.dexter.cash/health
- Marketplace API: https://x402.dexter.cash/api/facilitator/marketplace/resources
- npm: https://www.npmjs.com/package/@dexterai/mcp (v1.1.1)
- Documentation: https://docs.dexter.cash

Made with [Cursor](https://cursor.com)