### PR TITLE
Add Blueprint Agentic Staking (Solentic) to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ AI agents and autonomous systems built for Solana.
 - [Splatworld](https://splatworld.io) - Agent social platform for AI agents to collaborate and vote to generate their own metaverse of 3D gaussian splat worlds and implementing an agentic economy powered by x402.
 - [SP3ND Agent Skill](https://github.com/kent-x1/sp3nd-agent-skill) - Agent skill for buying products from Amazon using USDC on Solana. Fully autonomous via x402 payment protocol — register, build a cart, place an order, and pay with USDC in a single API flow. 0% platform fee, no KYC, free Prime shipping to 200+ countries across 22 Amazon marketplaces.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
+- [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 
 ## Developer Tools
 


### PR DESCRIPTION
## What

Adds [Blueprint Agentic Staking (Solentic)](https://solentic.theblueprint.xyz) to the AI Agents section.

## Why

Blueprint is the first native Solana staking infrastructure purpose-built for AI agents. No other validator offers MCP tools, OpenAPI specs, A2A agent cards, or llms.txt for staking. Agents with SOL in their wallets (via Solana Agent Kit, ElizaOS, Coinbase AgentKit, etc.) currently have no way to natively stake with a specific validator — Blueprint fills this gap.

## What it provides

- **18 MCP tools** at `https://solentic.theblueprint.xyz/mcp` — stake, unstake, withdraw, simulate, verify, validator info, APY, performance, infrastructure, epoch timing, and more
- **21 REST endpoints** at `/api/v1/*` — for agents without native MCP support
- **13 A2A skills** via `/.well-known/agent.json`
- **Full AI discovery layer** — llms.txt, llms-full.txt, OpenAPI 3.1, ai-plugin.json, Schema.org JSON-LD
- **Zero custody** — unsigned base64 transactions, agents sign client-side
- **~6% APY** (staking + Jito MEV) via Blueprint validator
- **Enterprise hardware** — AMD EPYC 9654, 768GB DDR5, dual NVMe, 10Gbps, active + hot standby
- **On-chain attribution** — Memo Program instruction on every transaction
- **No auth required** — all endpoints public

## Links

- **Live:** https://solentic.theblueprint.xyz
- **GitHub:** https://github.com/mbrassey/solentic
- **Docs:** https://solentic.theblueprint.xyz/docs
- **API Explorer:** https://solentic.theblueprint.xyz/api-docs
- **OpenAPI:** https://solentic.theblueprint.xyz/openapi.json
- **Validator:** [StakeWiz](https://stakewiz.com/validator/528hi3StRe7uGjt99d35myh95JPc2MqBEHTPYcEhqMg5) | [Validators.app](https://www.validators.app/validators/2Wf9V9rPeVRUTfmWdPedCJuWVr6MFfyLuigEq42DuMDc?network=mainnet)