### PR TITLE
Add Solana Compass CLI to agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ AI coding skills that enhance developer productivity on Solana.
 
 AI agents and autonomous systems built for Solana.
 
+- [Solana Compass CLI](https://github.com/solanaguide/solana-cli) - Ready-to-use Solana CLI allowing AI agents to use natural language commands to trade tokens, stake, lend, use prediction markets, make x402 payments, and manage wallets + portfolios without writing code.
 - [Chronoeffector AI Arena](https://arena.chronoeffector.ai) - Chronoeffector AI is a decentralized platform building a fully autonomous AI agent trading arena on Solana, enabling users to deploy AI agents for trading cryptocurrencies, stocks, commodities, and prediction markets.
 - [Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit) - Open-source toolkit connecting AI agents to 30+ Solana protocols with 50+ actions including token operations, NFTs, and swaps. Compatible with Eliza, LangChain, and Vercel AI SDK.
 - [Eliza Framework](https://github.com/elizaOS/eliza) - Lightweight TypeScript AI agent framework with Solana integrations, Twitter/X bots, and character-based configuration for agent behaviors.


### PR DESCRIPTION
Adds Solana Compass CLI — a command-line tool designed as an execution layer for AI agents on Solana. Any LLM with shell access can use it immediately  (available as a Claude Code plugin, ClawHub skill, and npm package). Commands read like English (sol token swap 50 usdc bonk) with structured --json output. Covers swaps, staking, lending, LP, prediction markets, x402 payments, and portfolio tracking. Configurable permissions and transaction limits for safe autonomous operation.