### PR TITLE
Add readtheskill to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ AI agents and autonomous systems built for Solana.
 - [SP3ND Agent Skill](https://github.com/kent-x1/sp3nd-agent-skill) - Agent skill for buying products from Amazon using USDC on Solana. Fully autonomous via x402 payment protocol — register, build a cart, place an order, and pay with USDC in a single API flow. 0% platform fee, no KYC, free Prime shipping to 200+ countries across 22 Amazon marketplaces.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
+- [readtheskill](https://github.com/readtheskill/readtheskill) - Open-source experiment measuring how AI agent skill files propagate through agent networks and drive on-chain activity on Solana, with a live dashboard tracking agent discovery and participation metrics.
 
 ## Developer Tools
 


### PR DESCRIPTION
## Summary

- Adds [readtheskill](https://github.com/readtheskill/readtheskill) to the **AI Agents** section
- Open-source experiment measuring how AI agent skill files (SKILL.md) propagate through agent networks and drive on-chain activity on Solana
- Features a live dashboard at [readtheskill.com](https://readtheskill.com) tracking agent discovery and participation metrics
- Full working codebase: Next.js frontend + Express API with PostgreSQL/Redis backend, deployed on Railway and Vercel
- Published on [skills.sh](https://skills.sh) and [ClawHub](https://clawhub.ai)

## Why it fits

This is an open-source research project studying AI agent information propagation — how skill files spread through agent ecosystems and whether they can drive real on-chain behavior. The live dashboard and API provide transparent, public data on agent discovery patterns.

## Checklist

- [x] Related to AI and Solana development
- [x] Added to appropriate category (AI Agents)
- [x] Concise description
- [x] Actively maintained with working code