### PR TITLE
Add TradeRouter skill and mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ AI coding skills that enhance developer productivity on Solana.
 - [sanctum-skill](https://github.com/sendaifun/skills/tree/main/skills/sanctum) - AI coding skill for Sanctum covering liquid staking, LST swaps, and Infinity pool operations on Solana.
 - [pnp-markets-skill](https://github.com/pnp-protocol/solana-skill) - AI coding skill for PNP Protocol covering permissionless prediction markets on Solana with V2 AMM, P2P betting, custom oracle settlement, and social media-linked markets.
 - [Sentients](https://github.com/koshmade/sentients.wtf) - AI agents minting unique inscriptions on Solana. First AI Agent-Native Protocol with autonomous wallets and deterministic art generated from blockchain entropy.
-- [TradeRouter-skill](https://github.com/re-bruce-wayne/openclaw-skills/blob/main/trade-router/SKILL.md) - AI coding skill for TradeRouter covering Solana token swaps, MEV-protected transaction submission, and market-cap-based limit/trailing/TWAP orders via REST and WebSocket.
+- [TradeRouter-skill](https://github.com/TradeRouter/trade-router-skill) - AI coding skill for TradeRouter covering Solana token swaps, MEV-protected transaction submission, and market-cap-based limit/trailing/TWAP orders via REST and WebSocket.
 
 ### Infrastructure
 
@@ -99,7 +99,7 @@ AI-enhanced development tools for the Solana ecosystem.
 - [surfpool-skill](https://github.com/sendaifun/skills/tree/main/skills/surfpool) - AI coding skill for Surfpool, a Solana development environment with mainnet forking, cheatcodes, and Infrastructure as Code.
 - [Quicknode MCP](https://www.npmjs.com/package/@quicknode/mcp) - MCP server that lets AI agents provision and manage Quicknode blockchain infrastructure through natural language — set up Solana endpoints, monitor usage, and unlock blockchain operations without leaving your AI assistant.
 - [Quicknode RPC via x402](https://www.quicknode.com/docs/build-with-ai/x402-payments) - Pay-per-request access to Solana endpoints using the x402 payment protocol. No signup, no API keys — pay with USDC on Solana and make calls to Solana autonomously. Includes a [reference implementation](https://github.com/quiknode-labs/qn-x402-examples).
-- [TradeRouter MCP](https://www.npmjs.com/package/@re-bruce-wayne/trade-router-mcp) - MCP server for TradeRouter enabling AI agents to execute Solana swaps, place limit/trailing/TWAP orders, and manage positions via natural language with WebSocket-authenticated order management.
+- [TradeRouter MCP](https://www.npmjs.com/package/@traderouter/trade-router-mcp) - MCP server for TradeRouter enabling AI agents to execute Solana swaps, place limit/trailing/TWAP orders, and manage positions via natural language with WebSocket-authenticated order management.
 
 ## Learning Resources
 


### PR DESCRIPTION
Adding **traderouter-skill** to the DeFi section and **TradeRouter MCP** to the Developer Tools section.

**What it is:** An AI coding skill and MCP server for building Solana trading agents using the TradeRouter API — covering instant swaps, MEV-protected submission, and a full WebSocket-based order engine.

**What the skill covers:**
- Instant token swaps via `POST /swap` with MEV-protected submission via Jito (`POST /protect`)
- Market-cap-based limit orders (take-profit, stop-loss, dip buy, breakout)
- Trailing stop orders (`trailing_sell` / `trailing_buy`)
- TWAP execution with configurable frequency and duration
- Combo orders: `limit+TWAP`, `trailing+TWAP`, `limit+trailing`, `limit+trailing+TWAP`
- WebSocket Ed25519 challenge–response authentication
- DCA implementation, order management (list, check, cancel, extend)
- Safety guards: kill switch, daily loss limit, per-trade cap, token cooldown, dry-run mode

**What the MCP covers:**
- 14 tools for Claude and other AI agents to trade via natural language
- Persistent WebSocket connection with auto-reconnect and fill auto-execution
- Server signature verification (trust anchor hardcoded, key rotation supported)

**Live on Solana Mainnet:** [traderouter.ai](https://traderouter.ai/) — API at `api.traderouter.ai`