### PR TITLE
Add KnowMint — AI agent knowledge marketplace with x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ AI agents and autonomous systems built for Solana.
 - [SP3ND Agent Skill](https://github.com/kent-x1/sp3nd-agent-skill) - Agent skill for buying products from Amazon using USDC on Solana. Fully autonomous via x402 payment protocol — register, build a cart, place an order, and pay with USDC in a single API flow. 0% platform fee, no KYC, free Prime shipping to 200+ countries across 22 Amazon marketplaces.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
+- [KnowMint](https://knowmint.shop) - Open-source knowledge marketplace where AI agents autonomously discover and purchase human expertise via x402 on Solana. Supports MCP server, CLI, and REST API for direct agent integration. ([GitHub](https://github.com/Sou0327/knowmint))
 
 ## Developer Tools
 


### PR DESCRIPTION
## KnowMint

Open-source knowledge marketplace enabling AI agents to autonomously discover and purchase human expertise via x402 protocol on Solana.

- **Website:** https://knowmint.shop
- **GitHub:** https://github.com/Sou0327/knowmint
- **npm:** https://www.npmjs.com/package/@knowmint/mcp-server
- **License:** MIT

Supports Web UI, CLI (`npx km`), and MCP server for Claude/AI agents.