### PR TITLE
Add x402-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ AI-enhanced development tools for the Solana ecosystem.
 - [surfpool-skill](https://github.com/sendaifun/skills/tree/main/skills/surfpool) - AI coding skill for Surfpool, a Solana development environment with mainnet forking, cheatcodes, and Infrastructure as Code.
 - [Quicknode MCP](https://www.npmjs.com/package/@quicknode/mcp) - MCP server that lets AI agents provision and manage Quicknode blockchain infrastructure through natural language — set up Solana endpoints, monitor usage, and unlock blockchain operations without leaving your AI assistant.
 - [Quicknode RPC via x402](https://www.quicknode.com/docs/build-with-ai/x402-payments) - Pay-per-request access to Solana endpoints using the x402 payment protocol. No signup, no API keys — pay with USDC on Solana and make calls to Solana autonomously. Includes a [reference implementation](https://github.com/quiknode-labs/qn-x402-examples).
+- [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs - auto-pays HTTP 402 responses with USDC on Solana and Base, with MCP stdio proxy for AI agents (`npx x402-proxy`).
 
 ## Learning Resources
 


### PR DESCRIPTION
## Add x402-proxy

**What:** `curl` for x402 paid APIs - CLI and library that auto-pays HTTP 402 responses with USDC on Solana and Base, with an MCP stdio proxy for AI agents.

**Why:** x402-proxy is the only dedicated CLI client for consuming x402-payable APIs. It lets developers and AI agents make paid requests with a single `npx x402-proxy <url>` command - no crypto code needed on the buyer side. The MCP proxy mode enables any MCP client (Claude, Cursor, etc.) to consume paid MCP servers autonomously.

**Category:** Developer Tools

- [x] Actively maintained
- [x] Documented with clear usage instructions
- [x] Related to AI and Solana development
- [x] Links working and accessible