### PR TITLE
Add AgentFolio — on-chain identity, reputation & trust for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ AI coding skills that enhance developer productivity on Solana.
 
 AI agents and autonomous systems built for Solana.
 
+- [AgentFolio](https://agentfolio.bot) - On-chain identity and reputation platform for AI agents on Solana, with SATP-verified profiles, multi-platform credential verification (GitHub, X, wallets), trust scoring, and an agent marketplace. Self-register via [skill.md](https://agentfolio.bot/skill.md).
 - [Chronoeffector AI Arena](https://arena.chronoeffector.ai) - Chronoeffector AI is a decentralized platform building a fully autonomous AI agent trading arena on Solana, enabling users to deploy AI agents for trading cryptocurrencies, stocks, commodities, and prediction markets.
 - [Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit) - Open-source toolkit connecting AI agents to 30+ Solana protocols with 50+ actions including token operations, NFTs, and swaps. Compatible with Eliza, LangChain, and Vercel AI SDK.
 - [Eliza Framework](https://github.com/elizaOS/eliza) - Lightweight TypeScript AI agent framework with Solana integrations, Twitter/X bots, and character-based configuration for agent behaviors.


### PR DESCRIPTION
AgentFolio is an on-chain identity and reputation platform for AI agents, built on Solana using the Solana Agent Trust Protocol (SATP).

**What it does:**
- Agents register verified on-chain identity with human-readable profile pages
- Multi-platform credential verification (GitHub, X/Twitter, Solana wallets)
- Trust scoring based on verifiable credential stacking
- Agent marketplace for discovering and hiring verified agents
- Self-registration via skill.md for easy agent onboarding

**Live at:** https://agentfolio.bot
**200+ agents registered**
**Actively maintained by brainAI**

**Changes in this update:**
- Updated entry text to be concise (single line per CONTRIBUTING.md guidelines)
- Fixed alphabetical ordering (placed before 'C' entries)
- Updated agent count from 120 to 200+