### PR TITLE
Add Unbrowse — agent browser & universal API discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ AI-enhanced development tools for the Solana ecosystem.
 - [surfpool-skill](https://github.com/sendaifun/skills/tree/main/skills/surfpool) - AI coding skill for Surfpool, a Solana development environment with mainnet forking, cheatcodes, and Infrastructure as Code.
 - [Quicknode MCP](https://www.npmjs.com/package/@quicknode/mcp) - MCP server that lets AI agents provision and manage Quicknode blockchain infrastructure through natural language — set up Solana endpoints, monitor usage, and unlock blockchain operations without leaving your AI assistant.
 - [Quicknode RPC via x402](https://www.quicknode.com/docs/build-with-ai/x402-payments) - Pay-per-request access to Solana endpoints using the x402 payment protocol. No signup, no API keys — pay with USDC on Solana and make calls to Solana autonomously. Includes a [reference implementation](https://github.com/quiknode-labs/qn-x402-examples).
-- [Unbrowse](https://github.com/unbrowse-ai/unbrowse) - Agent browser and universal API discovery tool that captures network traffic, reverse-engineers API endpoints from any website, and publishes reusable skills to a shared marketplace. x402-enabled for autonomous USDC payments on Solana.
+- [Unbrowse](https://github.com/unbrowse-ai/unbrowse) - Agent browser that auto-discovers API endpoints from any website and publishes reusable skills to a shared marketplace. Ships with pre-learned skills for Solana DeFi protocols (Jupiter, Raydium, etc.) and x402-enabled for autonomous USDC payments on Solana.
 
 ## Learning Resources
 


### PR DESCRIPTION
## Summary
- Adds [Unbrowse](https://github.com/unbrowse-ai/unbrowse) to the Developer Tools section
- Unbrowse is an agent browser that captures network traffic, reverse-engineers API endpoints from any website, and publishes reusable skills to a shared marketplace — so one agent learns a site once and every later agent gets the fast path
- Works with Claude Code, Cursor, Codex, Windsurf, and any agent host that can call a local CLI or skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)