### PR TITLE
Add Stockfilm — vintage footage licensing via x402 USDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ AI agents and autonomous systems built for Solana.
 - [SP3ND Agent Skill](https://github.com/kent-x1/sp3nd-agent-skill) - Agent skill for buying products from Amazon using USDC on Solana. Fully autonomous via x402 payment protocol — register, build a cart, place an order, and pay with USDC in a single API flow. 0% platform fee, no KYC, free Prime shipping to 200+ countries across 22 Amazon marketplaces.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
+- [Stockfilm](https://github.com/ReplicantArmy/stockfilm-mcp) - MCP server for licensing 217,000+ authentic vintage 8mm home movie clips (1930s-1980s) via x402 USDC payments on Solana. 6 tools: search, details, visual similarity, rough-cut timeline, rights verification, and instant licensing at $10 USDC per clip. Real archival film restored in 4K.
 
 ## Developer Tools
 


### PR DESCRIPTION
Adds Stockfilm to AI Agents section.

MCP server for licensing 217,000+ authentic vintage 8mm home movie clips (1930s-1980s) via x402 USDC payments on Solana mainnet. 6 tools over Streamable HTTP. $10 USDC per clip. Real archival film restored in 4K.

- **MCP:** `https://api.stockfilm.com/mcp`
- **x402:** `https://api.stockfilm.com/x402/clip/{id}/license`
- **Solana payTo:** `FERR1XDCsvLRzU8U29baMY4XvZ8kwk52tUjqy3SaDRtQ`
- **GitHub:** https://github.com/ReplicantArmy/stockfilm-mcp