### PR TITLE
Add mpp-spl to Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ AI coding skills that enhance developer productivity on Solana.
 - [squads-skill](https://github.com/sendaifun/skills/tree/main/skills/squads) - AI coding skill for Squads Protocol covering multisig wallets, smart accounts, and account abstraction on Solana.
 - [svm-skill](https://github.com/helius-labs/core-ai/tree/main/helius-skills/svm) - Official Helius skill for exploring Solana's architecture and protocol internals covering the SVM execution engine, account model, consensus, transactions, validator economics, and token extensions using the Helius blog, SIMDs, and Agave/Firedancer source code.
 - [switchboard-skill](https://github.com/sendaifun/skills/tree/main/skills/switchboard) - AI coding skill for Switchboard Oracle covering permissionless price feeds, on-demand data, VRF randomness, and Surge streaming on Solana.
+- [mpp-spl](https://github.com/nullxnothing/mpp-spl) - SPL token and pump.fun payment layer for the Machine Payments Protocol (MPP). Token registry, Jupiter + bonding curve price providers, and charge config resolver for gating APIs behind any Solana token.
 - [bitget-wallet-skill](https://github.com/bitget-wallet-ai-lab/bitget-wallet-skill) - AI agent skill for Bitget Wallet covering multi-chain token swaps, cross-chain bridges, gasless transactions, security audits, and real-time market data across 7 chains including Solana.
 
 ## AI Agents


### PR DESCRIPTION
Adds [mpp-spl](https://github.com/nullxnothing/mpp-spl) to the Infrastructure section.

**What it is:** TypeScript library that makes any SPL token — including pre-graduation pump.fun tokens — usable as a payment method in MPP-gated APIs.

**Why it belongs here:**
- First community tooling for the Solana MPP SDK (`@solana/mpp`)
- Includes a PumpFun bonding curve price provider (reads PDAs on-chain for tokens Jupiter doesn't index yet)
- Zero runtime dependencies, peer deps only (`@solana/mpp`, `@solana/kit`, `mppx`)
- 85 tests, MIT licensed

**Links:**
- GitHub: https://github.com/nullxnothing/mpp-spl
- npm: https://www.npmjs.com/package/mpp-spl