### PR TITLE
Add vybes.fun — AI agent token launchpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ AI agents and autonomous systems built for Solana.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 - [MoonPay CLI](https://moonpay.com/agents) - AI agent CLI for token swaps, bridging, DCA, wallet management, fiat on/off-ramp, and prediction markets on Solana. Includes Claude Code skills for autonomous trading workflows.
+- [Vybes.fun](https://vybes.fun) - Solana token launchpad and prediction markets built for AI agents, with a free [Agent API](https://vybes.fun/developers) for token launches, AI logo generation, and betting, a 0.25% referral fee on every trade, [ElizaOS plugin](https://github.com/AICre8dev/plugin-vybes), [Solana Agent Kit integration](https://github.com/AICre8dev/solana-agent-kit-vybes), and [skill.md](https://vybes.fun/skill.md) for OpenClaw agent discovery.
 
 ## Developer Tools
 


### PR DESCRIPTION
## Summary

- Adds [vybes.fun](https://vybes.fun) to the **AI Agents** section
- Vybes.fun is a Solana token launchpad and prediction markets platform built for AI agents
- Ships with a free Agent API (token launches, AI logo generation, prediction betting), 0.25% referral fee on trades, an ElizaOS plugin, Solana Agent Kit integration, and skill.md for OpenClaw agent discovery

## Why it belongs

Vybes.fun is purpose-built for AI agents to autonomously launch tokens, generate logos, and place prediction bets on Solana — all via a documented API. The ElizaOS plugin and Solana Agent Kit integration make it composable with the major agent frameworks already listed in this repo.

## Links

- App: https://vybes.fun
- Agent API docs: https://vybes.fun/developers
- skill.md: https://vybes.fun/skill.md
- ElizaOS plugin: https://github.com/AICre8dev/plugin-vybes
- Solana Agent Kit: https://github.com/AICre8dev/solana-agent-kit-vybes

🤖 Generated with [Claude Code](https://claude.com/claude-code)