### PR TITLE
Add MadeOnSol — Solana KOL & deployer intelligence for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ AI-enhanced development tools for the Solana ecosystem.
 - [Quicknode RPC via x402](https://www.quicknode.com/docs/build-with-ai/x402-payments) - Pay-per-request access to Solana endpoints using the x402 payment protocol. No signup, no API keys — pay with USDC on Solana and make calls to Solana autonomously. Includes a [reference implementation](https://github.com/quiknode-labs/qn-x402-examples).
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs - auto-pays HTTP 402 responses with USDC on Solana and Base, with MCP stdio proxy for AI agents (`npx x402-proxy`).
 - [Unbrowse](https://github.com/unbrowse-ai/unbrowse) - Agent browser that auto-discovers API endpoints from any website and publishes reusable skills to a shared marketplace. Ships with pre-learned skills for Solana DeFi protocols (Jupiter, Raydium, etc.) and x402-enabled for autonomous USDC payments on Solana.
+- [MadeOnSol](https://madeonsol.com) - Solana KOL wallet and Pump.fun deployer intelligence for AI agents, available as an MCP server, ElizaOS plugin, Solana Agent Kit plugin, LangChain/CrewAI tools, and x402-enabled API — tracking 950+ KOL wallets, 6,700+ deployers, and all-DEX trades.
 
 ## Learning Resources
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ AI-enhanced development tools for the Solana ecosystem.
 - [Quicknode RPC via x402](https://www.quicknode.com/docs/build-with-ai/x402-payments) - Pay-per-request access to Solana endpoints using the x402 payment protocol. No signup, no API keys — pay with USDC on Solana and make calls to Solana autonomously. Includes a [reference implementation](https://github.com/quiknode-labs/qn-x402-examples).
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs - auto-pays HTTP 402 responses with USDC on Solana and Base, with MCP stdio proxy for AI agents (`npx x402-proxy`).
 - [Unbrowse](https://github.com/unbrowse-ai/unbrowse) - Agent browser that auto-discovers API endpoints from any website and publishes reusable skills to a shared marketplace. Ships with pre-learned skills for Solana DeFi protocols (Jupiter, Raydium, etc.) and x402-enabled for autonomous USDC payments on Solana.
-- [MadeOnSol](https://madeonsol.com) - Solana KOL wallet and Pump.fun deployer intelligence for AI agents, available as an MCP server, ElizaOS plugin, Solana Agent Kit plugin, LangChain/CrewAI tools, and x402-enabled API — tracking 950+ KOL wallets, 6,700+ deployers, and all-DEX trades.
+- [MadeOnSol](https://madeonsol.com) - Solana + Robinhood Chain trading intelligence for AI agents: 1,000+ tracked KOL wallets, 15,500+ Pump.fun deployers scored, and an all-DEX trade firehose. 104 MCP tools, plus ElizaOS and Solana Agent Kit plugins, and x402 pay-per-call on both chains.
 
 ## Learning Resources
 


### PR DESCRIPTION
## What is MadeOnSol?

[MadeOnSol](https://madeonsol.com) provides Solana + Robinhood Chain trading intelligence as AI-native tooling:

- **MCP Server** — [`mcp-server-madeonsol`](https://www.npmjs.com/package/mcp-server-madeonsol) on npm (104 tools) for Claude, Cursor, and other MCP-compatible clients, plus [`mcp-server-robinhood-chain`](https://www.npmjs.com/package/mcp-server-robinhood-chain)
- **ElizaOS plugin** — [`@madeonsol/plugin-madeonsol`](https://www.npmjs.com/package/@madeonsol/plugin-madeonsol)
- **Solana Agent Kit plugin** — [`solana-agent-kit-plugin-madeonsol`](https://www.npmjs.com/package/solana-agent-kit-plugin-madeonsol)
- **x402 protocol** — Pay-per-request API access with USDC on Solana and USDG on Robinhood Chain

### Data coverage

- 1,000+ tracked KOL wallets with PnL and trade history
- 15,500+ Pump.fun deployers scored for reputation
- All-DEX trade stream (Raydium, Orca, Meteora, PumpSwap, etc.)

### Links

- Website: https://madeonsol.com
- GitHub: https://github.com/MadeOnSol/mcp-server-madeonsol
- npm: https://www.npmjs.com/package/mcp-server-madeonsol

---
_Update 2026-09-10: refreshed stats, added Robinhood Chain support, fixed the repo link (moved from the LamboPoewert personal org to MadeOnSol)._