### PR TITLE
Add UZPROOF — Proof-of-Use verification skill and Agent Kit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ AI coding skills that enhance developer productivity on Solana.
 - [svm-skill](https://github.com/helius-labs/core-ai/tree/main/helius-skills/svm) - Official Helius skill for exploring Solana's architecture and protocol internals covering the SVM execution engine, account model, consensus, transactions, validator economics, and token extensions using the Helius blog, SIMDs, and Agave/Firedancer source code.
 - [switchboard-skill](https://github.com/sendaifun/skills/tree/main/skills/switchboard) - AI coding skill for Switchboard Oracle covering permissionless price feeds, on-demand data, VRF randomness, and Surge streaming on Solana.
 - [bitget-wallet-skill](https://github.com/bitget-wallet-ai-lab/bitget-wallet-skill) - AI agent skill for Bitget Wallet covering multi-chain token swaps, cross-chain bridges, gasless transactions, security audits, and real-time market data across 7 chains including Solana.
+- [uzproof-agent-skill](https://github.com/uzproof/uzproof-agent-skill) - AI coding skill for UZPROOF Proof-of-Use verification covering on-chain activity checks (swaps, staking, holdings, NFTs) across 14 Solana protocols, anti-fraud scoring, and SAS attestation.
 
 ## AI Agents
 
@@ -86,6 +87,7 @@ AI agents and autonomous systems built for Solana.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 - [MoonPay CLI](https://moonpay.com/agents) - AI agent CLI for token swaps, bridging, DCA, wallet management, fiat on/off-ramp, and prediction markets on Solana. Includes Claude Code skills for autonomous trading workflows.
+- [solana-agent-kit-plugin-uzproof](https://github.com/uzproof/solana-agent-kit-plugin-uzproof) - Solana Agent Kit plugin for on-chain Proof-of-Use verification across 14 Solana protocols with anti-fraud scoring and SAS attestation. SDK on [npm](https://www.npmjs.com/package/solana-agent-kit-plugin-uzproof).
 
 ## Developer Tools
 


### PR DESCRIPTION
## What is UZPROOF?

Proof-of-Use verification layer for Solana. Verifies that wallets actually performed real on-chain actions (swaps, staking, holdings, NFTs) across 14 protocols with anti-fraud scoring. First Proof-of-Use attestor on Solana Attestation Service (SAS).

## Added entries

**AI Coding Skills → Infrastructure:**
- [uzproof-agent-skill](https://github.com/uzproof/uzproof-agent-skill) — AI coding skill for Claude Code, Cursor, Copilot, and 30+ AI tools via [agentskills.io](https://agentskills.io) format.

**AI Agents:**
- [solana-agent-kit-plugin-uzproof](https://github.com/uzproof/solana-agent-kit-plugin-uzproof) — Runtime plugin for [Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit). Published on [npm](https://www.npmjs.com/package/solana-agent-kit-plugin-uzproof).

## Links

- Website: [uzproof.com](https://uzproof.com)
- SDK: [@uzproof/verify](https://www.npmjs.com/package/@uzproof/verify) on npm
- Docs: [uzproof.com/docs](https://uzproof.com/docs)