### PR TITLE
Add TextAI API to AI Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ AI agents and autonomous systems built for Solana.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 - [MoonPay CLI](https://moonpay.com/agents) - AI agent CLI for token swaps, bridging, DCA, wallet management, fiat on/off-ramp, and prediction markets on Solana. Includes Claude Code skills for autonomous trading workflows.
+- [TextAI API](https://github.com/mokchou/textai-api) - AI text processing API (summarize, keywords, translate) with native USDC payments on Solana. No subscription required — pay per request with SPL tokens. Built on Deno with Hono.js, includes demo mode with 100 free credits. [Live API](https://textai-api.overtek.deno.net).
 
 ## Developer Tools
 


### PR DESCRIPTION
## What

Adds [TextAI API](https://github.com/mokchou/textai-api) to the AI Agents section.

## Description

TextAI API is an AI text processing API (summarize, keywords, translate) with native USDC payments on Solana. Key features:

- **Pay-per-request with USDC** on Solana (SPL token verification with anti-double-spend)
- No subscription required
- Built on Deno with Hono.js
- Demo mode with 100 free credits to try before paying
- Live at https://textai-api.overtek.deno.net

This fits the AI Agents section alongside other USDC/Solana payment tools like SP3ND Agent Skill and OpenDexter.