### PR TITLE
Add Hive Intelligence (crypto market infrastructure for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ AI-enhanced development tools for the Solana ecosystem.
 - [Quicknode RPC via x402](https://www.quicknode.com/docs/build-with-ai/x402-payments) - Pay-per-request access to Solana endpoints using the x402 payment protocol. No signup, no API keys — pay with USDC on Solana and make calls to Solana autonomously. Includes a [reference implementation](https://github.com/quiknode-labs/qn-x402-examples).
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs - auto-pays HTTP 402 responses with USDC on Solana and Base, with MCP stdio proxy for AI agents (`npx x402-proxy`).
 - [Unbrowse](https://github.com/unbrowse-ai/unbrowse) - Agent browser that auto-discovers API endpoints from any website and publishes reusable skills to a shared marketplace. Ships with pre-learned skills for Solana DeFi protocols (Jupiter, Raydium, etc.) and x402-enabled for autonomous USDC payments on Solana.
+- [Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp) - Managed crypto market infrastructure for AI — live prices, DeFi activity, wallet positions, and token risk on Solana (via Helius) alongside every major EVM chain, exposed through a single MCP server, REST API, or CLI. Hundreds of normalized tools across 14 category-scoped endpoints covering SPL token pricing, Solana DEX analytics, wallet positions, rug-check risk signals, and derivatives data.
 
 ## Learning Resources
 


### PR DESCRIPTION
Adds [Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp) to the **Developer Tools** section.

**What Hive is:** institutional-grade crypto market infrastructure for AI — a managed MCP server, REST API, and CLI that connect AI agents to live crypto prices, DeFi activity, wallet positions, and token risk across every major chain. Hundreds of normalized tools across 14 category-scoped endpoints. Works with Claude Desktop, Claude Code, Cursor, ChatGPT Desktop, Windsurf, VS Code (GitHub Copilot Chat), Gemini CLI, and any MCP-compatible client.

**Solana coverage (per CONTRIBUTING.md requirement "related to AI and Solana development"):** Hive integrates Helius for Solana RPC/DAS/priority-fees alongside chain-agnostic data sources (Codex, GoldRush) that index Solana. Solana tooling includes SPL token pricing and metadata, on-chain DEX pool analytics (including Solana DEXs), OHLCV for Solana tokens, Solana wallet DeFi positions and NFTs, and rug-check risk signals on Solana meme tokens — all queryable via MCP or REST. The project is actively maintained, open source on GitHub, and documented; no token promotion.

**Why Developer Tools fits:** Section already includes similar MCP servers for Solana developers — Solana Developer MCP, DFlow MCP Server, Deside MCP, Phantom Connect SDK, Quicknode MCP, `x402-proxy` — i.e. MCP / API infrastructure usable by AI coding agents building on Solana. Hive adds the missing market-data and risk layer. Entry uses the section's `- [Name](url) - description.` format.
