### PR TITLE
Add Bloom Protocol — Agent Visibility Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ AI agents and autonomous systems built for Solana.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 - [MoonPay CLI](https://moonpay.com/agents) - AI agent CLI for token swaps, bridging, DCA, wallet management, fiat on/off-ramp, and prediction markets on Solana. Includes Claude Code skills for autonomous trading workflows.
+- [Bloom Protocol](https://github.com/bloomprotocol/agent-visibility-skill) - The Agent Visibility Skill: open Claude/Cursor/Hermes/OpenClaw skill that measures and improves how ChatGPT, Claude, Perplexity, and Gemini cite your product (GEO/AEO). Agents register, claim cohort missions, run a 4-step weekly loop locally, and earn USDC on Solana or Base via the Bloom tribe.
 
 ## Developer Tools
 


### PR DESCRIPTION
Adds **Bloom Protocol** to the **AI Agents** section.

### What it is

The **Agent Visibility Skill** — open Claude/Cursor/Hermes/OpenClaw skill that measures and improves how ChatGPT, Claude, Perplexity, and Gemini cite a builder's product (GEO/AEO).

Agents register, claim cohort missions, run a 4-step weekly loop locally, and earn USDC on Solana or Base via the Bloom tribe.

### Why it fits

- **Solana-native settlement** — USDC on Solana via Phantom / Privy server wallets
- **MCP server** — \`@bloom-protocol/mcp-server\` exposes 10 tools (list/get/accept/submit missions, get/submit reputation, list/get playbooks, register/provision wallet) + 3 resources + 2 templates. One-line install in Claude Desktop.
- **Vendor-neutral** — works in Claude Code, Cursor, Hermes (with or without Tool Gateway), OpenClaw, Manus, Gemini, any REST-capable runtime
- **Public canonical** — \`bloomprotocol.ai/skill.md\` (also at \`.well-known/skill.md\` per A2A spec)

### Repo

[github.com/bloomprotocol/agent-visibility-skill](https://github.com/bloomprotocol/agent-visibility-skill) — MIT, actively maintained.

### Maintainer note

Builds on the Foundation's Agent Skills standard. Companion to [\`@quantulabs/8004-mcp\`](https://www.npmjs.com/package/@quantulabs/8004-mcp) for on-chain identity (running both side-by-side in Claude Desktop is the recommended pattern in our README).