### PR TITLE
Add Trade Router — non-custodial Solana swap MCP + skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ AI coding skills that enhance developer productivity on Solana.
 - [ranger-finance-skill](https://github.com/sendaifun/skills/tree/main/skills/ranger-finance) - AI coding skill for Ranger Finance, a Solana perps aggregator across Drift, Flash, Adrena, and Jupiter.
 - [raydium-skill](https://github.com/sendaifun/skills/tree/main/skills/raydium) - AI coding skill for Raydium Protocol covering CLMM, CPMM, AMM pools, LaunchLab token launches, farming, and Trade API on Solana.
 - [sanctum-skill](https://github.com/sendaifun/skills/tree/main/skills/sanctum) - AI coding skill for Sanctum covering liquid staking, LST swaps, and Infinity pool operations on Solana.
+- [trade-router-skill](https://github.com/re-bruce-wayne/openclaw-skills/tree/main/trade-router) - AI coding skill for Trade Router covering non-custodial Solana swaps with multi-DEX routing across Raydium, PumpSwap, Orca, and Meteora, Jito MEV-protected execution via /protect, and limit/trailing/TWAP/combo orders over WebSocket. The agent signs locally; the API never holds keys.
 - [pnp-markets-skill](https://github.com/pnp-protocol/solana-skill) - AI coding skill for PNP Protocol covering permissionless prediction markets on Solana with V2 AMM, P2P betting, custom oracle settlement, and social media-linked markets.
 - [Sentients](https://github.com/koshmade/sentients.wtf) - AI agents minting unique inscriptions on Solana. First AI Agent-Native Protocol with autonomous wallets and deterministic art generated from blockchain entropy.
 
-- [trade-router-skill](https://github.com/re-bruce-wayne/openclaw-skills/tree/main/trade-router) - AI coding skill for Trade Router covering non-custodial Solana swaps with multi-DEX routing across Raydium, PumpSwap, Orca, and Meteora, Jito MEV-protected execution via /protect, and limit/trailing/TWAP/combo orders over WebSocket. The agent signs locally; the API never holds keys.
 ### Infrastructure
 
 - [coingecko-skill](https://github.com/sendaifun/skills/tree/main/skills/coingecko) - AI coding skill for CoinGecko Solana API covering token prices, DEX pool data, OHLCV charts, and market analytics.
@@ -101,6 +101,7 @@ AI-enhanced development tools for the Solana ecosystem.
 - [Quicknode RPC via x402](https://www.quicknode.com/docs/build-with-ai/x402-payments) - Pay-per-request access to Solana endpoints using the x402 payment protocol. No signup, no API keys — pay with USDC on Solana and make calls to Solana autonomously. Includes a [reference implementation](https://github.com/quiknode-labs/qn-x402-examples).
 
 - [trade-router-mcp](https://www.npmjs.com/package/@traderouter/trade-router-mcp) - Non-custodial Solana swap & limit-order MCP server for AI agents. 21 tools: swap, limit, trailing, TWAP, DCA, and combo orders (limit+trailing+TWAP) across Raydium, PumpSwap, Orca, and Meteora. Jito MEV-protected, Ed25519 server-message verification, `TRADEROUTER_DRY_RUN` for safe testing. Install: `npx -y @traderouter/trade-router-mcp`.
+
 ## Learning Resources
 
 Educational resources combining AI and Solana development.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ AI coding skills that enhance developer productivity on Solana.
 - [pnp-markets-skill](https://github.com/pnp-protocol/solana-skill) - AI coding skill for PNP Protocol covering permissionless prediction markets on Solana with V2 AMM, P2P betting, custom oracle settlement, and social media-linked markets.
 - [Sentients](https://github.com/koshmade/sentients.wtf) - AI agents minting unique inscriptions on Solana. First AI Agent-Native Protocol with autonomous wallets and deterministic art generated from blockchain entropy.
 
+- [trade-router-skill](https://github.com/re-bruce-wayne/openclaw-skills/tree/main/trade-router) - AI coding skill for Trade Router covering non-custodial Solana swaps with multi-DEX routing across Raydium, PumpSwap, Orca, and Meteora, Jito MEV-protected execution via /protect, and limit/trailing/TWAP/combo orders over WebSocket. The agent signs locally; the API never holds keys.
 ### Infrastructure
 
 - [coingecko-skill](https://github.com/sendaifun/skills/tree/main/skills/coingecko) - AI coding skill for CoinGecko Solana API covering token prices, DEX pool data, OHLCV charts, and market analytics.
@@ -99,6 +100,7 @@ AI-enhanced development tools for the Solana ecosystem.
 - [Quicknode MCP](https://www.npmjs.com/package/@quicknode/mcp) - MCP server that lets AI agents provision and manage Quicknode blockchain infrastructure through natural language — set up Solana endpoints, monitor usage, and unlock blockchain operations without leaving your AI assistant.
 - [Quicknode RPC via x402](https://www.quicknode.com/docs/build-with-ai/x402-payments) - Pay-per-request access to Solana endpoints using the x402 payment protocol. No signup, no API keys — pay with USDC on Solana and make calls to Solana autonomously. Includes a [reference implementation](https://github.com/quiknode-labs/qn-x402-examples).
 
+- [trade-router-mcp](https://www.npmjs.com/package/@traderouter/trade-router-mcp) - Non-custodial Solana swap & limit-order MCP server for AI agents. 21 tools: swap, limit, trailing, TWAP, DCA, and combo orders (limit+trailing+TWAP) across Raydium, PumpSwap, Orca, and Meteora. Jito MEV-protected, Ed25519 server-message verification, `TRADEROUTER_DRY_RUN` for safe testing. Install: `npx -y @traderouter/trade-router-mcp`.
 ## Learning Resources
 
 Educational resources combining AI and Solana development.


### PR DESCRIPTION
## What

Adds two entries:

1. **DeFi (AI Coding Skills)** → `trade-router-skill` — points to the SKILL.md in `openclaw-skills/trade-router/` (the same SKILL.md that's live on ClawHub).
2. **Developer Tools** → `trade-router-mcp` — the npm-published MCP server `@traderouter/trade-router-mcp` wrapping the same API for use in Claude Desktop, Cursor, Cline, and any MCP-compatible client.

## What's distinctive vs other DeFi entries already in this list

Most entries currently use a single DEX (Jupiter most often). Trade Router differentiates on:

- **Multi-DEX routing** across Raydium, PumpSwap, Orca, Meteora (chosen per-token by liquidity)
- **11 order types** including 4 combo permutations (limit + trailing + TWAP)
- **Jito MEV-protected execution** via `/protect` Jito bundles
- **Ed25519-verified server messages** with a hardcoded trust anchor + a rotation slot (`TRADEROUTER_SERVER_PUBKEY_NEXT`)
- **`TRADEROUTER_DRY_RUN`** env var lets agents drive the full flow with no live tx — every write tool short-circuits to `{ dry_run: true, ... }`
- **Non-custodial**: `POST /swap` returns an unsigned tx, the agent signs locally, only the signed bundle goes to `/protect`. The private key never crosses the network. Full threat model in [SECURITY.md](https://github.com/TradeRouter/trade-router-mcp/blob/main/SECURITY.md).

## Verification

- npm: [`@traderouter/trade-router-mcp@1.0.10`](https://www.npmjs.com/package/@traderouter/trade-router-mcp), MIT, signed publish
- PyPI: [`traderouter-mcp@1.0.10`](https://pypi.org/project/traderouter-mcp/)
- MCP Registry: `ai.traderouter/trade-router-mcp@1.0.10` (`isLatest: true`)
- GitHub: [TradeRouter/trade-router-mcp](https://github.com/TradeRouter/trade-router-mcp) — CI green across Node 18/20/22, branch protected
- Glama listing: [glama.ai/mcp/servers/TradeRouter/trade-router-mcp](https://glama.ai/mcp/servers/TradeRouter/trade-router-mcp)
- VirusTotal: tarball + inner mjs both 0/62 detections — [report](https://www.virustotal.com/gui/file/cf3c2d92a7ab514ef7327197a5b4a603ed844ccac8b269b095f9f834bf2b2fd9)

Both entries fit existing format conventions in their respective sections.