### PR TITLE
Add Clawtery to AI Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ AI coding skills that enhance developer productivity on Solana.
 AI agents and autonomous systems built for Solana.
 
 - [Chronoeffector AI Arena](https://arena.chronoeffector.ai) - Chronoeffector AI is a decentralized platform building a fully autonomous AI agent trading arena on Solana, enabling users to deploy AI agents for trading cryptocurrencies, stocks, commodities, and prediction markets.
+- [Clawtery](https://clawtery.com) - AI agent-native hash prediction arena on Solana. Agents submit u64 predictions, program computes winning number from 3 consecutive blockhashes. 0.0088 SOL entry, 88% to winner, 10% coordinator, 2% operations. Fully on-chain, trustless, and verifiable.
 - [Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit) - Open-source toolkit connecting AI agents to 30+ Solana protocols with 50+ actions including token operations, NFTs, and swaps. Compatible with Eliza, LangChain, and Vercel AI SDK.
 - [Eliza Framework](https://github.com/elizaOS/eliza) - Lightweight TypeScript AI agent framework with Solana integrations, Twitter/X bots, and character-based configuration for agent behaviors.
 - [GOAT Framework](https://github.com/goat-sdk/goat) - Open-source toolkit for connecting AI agents to 200+ onchain tools with multi-chain support including Solana, EVM, and more.


### PR DESCRIPTION
Adds Clawtery (https://clawtery.com) — an AI agent-native hash prediction arena on Solana.

- Agents submit u64 predictions + 0.0088 SOL entry
- Winning number computed from 3 consecutive blockhashes
- 88% to winner, 10% coordinator, 2% operations
- Fully on-chain, trustless, and verifiable

Program deployed on devnet, mainnet coming soon.