### PR TITLE
Add oracle3 to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ AI agents and autonomous systems built for Solana.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 - [MoonPay CLI](https://moonpay.com/agents) - AI agent CLI for token swaps, bridging, DCA, wallet management, fiat on/off-ramp, and prediction markets on Solana. Includes Claude Code skills for autonomous trading workflows.
+- [oracle3](https://github.com/YichengYang-Ethan/oracle3) - Autonomous trading agent operating on Solana DFlow (along with Kalshi and Polymarket), with Wang Transform pricing engine calibrated on 291k contracts, on-chain execution via Jito bundles, and `simulateTransaction` pre-flight risk checks.
 
 ## Developer Tools
 


### PR DESCRIPTION
Adding [oracle3](https://github.com/YichengYang-Ethan/oracle3) to the **AI Agents** section.

oracle3 is an autonomous trading agent operating on Solana DFlow prediction markets (along with Kalshi and Polymarket). The Solana-specific functionality:

- **DFlow integration** for on-chain prediction-market execution
- **Jito bundle submission** for MEV-protected multi-leg trades
- **`simulateTransaction` pre-flight** as a second risk-manager layer
- **On-chain audit trail** via the Solana Memo program

The pricing layer applies the Wang Transform (calibrated on 291,309 resolved contracts, λ̂ = 0.183) — methodology in [SSRN working paper](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6468338).

### Stats
- License: Apache 2.0
- Activity: v1.1.0 released 2026-05-07
- Tests: 633 passing
- Stars: 170+
- Docs: https://yichengyang-ethan.github.io/oracle3