### PR TITLE
Add EconDash to AI Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ AI agents and autonomous systems built for Solana.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 - [MoonPay CLI](https://moonpay.com/agents) - AI agent CLI for token swaps, bridging, DCA, wallet management, fiat on/off-ramp, and prediction markets on Solana. Includes Claude Code skills for autonomous trading workflows.
+- [EconDash](https://econdash.org) - Global macroeconomic data API for AI agents with 753 indicators across 298 countries, supporting x402 and MPP payments including USDC on Solana via direct SPL token verification. 15 endpoints for GDP, inflation, employment, trade, and country profiles. ([OpenAPI](https://econdash.org/m2m-openapi.json)) ([Docs](https://econdash.org/docs/quick-start))
 
 ## Developer Tools
 


### PR DESCRIPTION
## Summary
- Added [EconDash](https://econdash.org) — global macroeconomic data API for AI agents
- 753 indicators across 298 countries (World Bank, FRED, OECD)
- 15 x402/MPP-protected endpoints supporting USDC on Solana via direct SPL token verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)