### PR TITLE
feat: add Spraay x402 Gateway to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ AI-enhanced development tools for the Solana ecosystem.
 - [Quicknode RPC via x402](https://www.quicknode.com/docs/build-with-ai/x402-payments) - Pay-per-request access to Solana endpoints using the x402 payment protocol. No signup, no API keys — pay with USDC on Solana and make calls to Solana autonomously. Includes a [reference implementation](https://github.com/quiknode-labs/qn-x402-examples).
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs - auto-pays HTTP 402 responses with USDC on Solana and Base, with MCP stdio proxy for AI agents (`npx x402-proxy`).
 - [Unbrowse](https://github.com/unbrowse-ai/unbrowse) - Agent browser that auto-discovers API endpoints from any website and publishes reusable skills to a shared marketplace. Ships with pre-learned skills for Solana DeFi protocols (Jupiter, Raydium, etc.) and x402-enabled for autonomous USDC payments on Solana.
+- [Spraay x402 Gateway](https://gateway.spraay.app) - Full-stack pay-per-call crypto infrastructure for AI agents. 88+ x402 endpoints across 19 categories: batch payments (15 chains), AI inference (200+ models), Bittensor decentralized AI, DeFi, escrow, ERC-4337 agent wallets, Robot Task Protocol, supply chain, GPU compute, and search/RAG. USDC on Base. MCP server on [Smithery](https://smithery.ai/server/@plagtech/spraay-x402-mcp). Google ADK community tool ([PR #95](https://github.com/google/adk-python/pull/95), merged). [Docs](https://docs.spraay.app) 
 
 ## Learning Resources
 


### PR DESCRIPTION
Adds Spraay x402 Gateway to the Developer Tools section.
**Spraay x402 Gateway** — full-stack pay-per-call crypto infrastructure for AI agents. 88+ x402 endpoints across 19 categories. USDC on Base via Coinbase x402 facilitator. 15-chain coverage.

- Gateway: https://gateway.spraay.app/
- Docs: https://docs.spraay.app/
- MCP: @plagtech/spraay-x402-mcp on Smithery (60+ tools)
- Merged into coinbase/x402 ecosystem
- Google ADK community tool (google/adk-python PR #95, merged)
- Listed on x402scan, Dexter (ERC-8004 Agent #27567), and pay-skills catalog (PR pending)