### PR TITLE
Add Mobile & Seeker subsection with seeker-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   - [General](#general)
   - [DeFi](#defi)
   - [Infrastructure](#infrastructure)
+  - [Mobile & Seeker](#mobile--seeker)
 - [AI Agents](#ai-agents)
 - [Developer Tools](#developer-tools)
 - [Learning Resources](#learning-resources)
@@ -68,6 +69,13 @@ AI coding skills that enhance developer productivity on Solana.
 - [svm-skill](https://github.com/helius-labs/core-ai/tree/main/helius-skills/svm) - Official Helius skill for exploring Solana's architecture and protocol internals covering the SVM execution engine, account model, consensus, transactions, validator economics, and token extensions using the Helius blog, SIMDs, and Agave/Firedancer source code.
 - [switchboard-skill](https://github.com/sendaifun/skills/tree/main/skills/switchboard) - AI coding skill for Switchboard Oracle covering permissionless price feeds, on-demand data, VRF randomness, and Surge streaming on Solana.
 - [bitget-wallet-skill](https://github.com/bitget-wallet-ai-lab/bitget-wallet-skill) - AI agent skill for Bitget Wallet covering multi-chain token swaps, cross-chain bridges, gasless transactions, security audits, and real-time market data across 7 chains including Solana.
+
+### Mobile & Seeker
+
+AI coding skills for Solana Mobile (Seeker) dApps.
+
+- [solana-mobile-dev-skill](https://github.com/solana-mobile/solana-mobile-dev-skill) - Official Solana Mobile skills covering Mobile Wallet Adapter (setup, connection, transactions), `.skr` domain resolution, and Seeker Genesis Token verification for React Native Expo apps.
+- [seeker-skills](https://github.com/Sarthib7/seeker-skills) - End-to-end skills for building a Seeker dApp: scaffold + Android toolchain, UX conventions (one-tap approval, haptics, AMOLED, 120 Hz), USDC/SOL payments via MWA, Seed Vault for wallet developers, and dApp Store APK signing + publishing via `@solana-mobile/dapp-store-cli`.
 
 ## AI Agents
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,8 @@ AI coding skills that enhance developer productivity on Solana.
 
 ### Mobile & Seeker
 
-AI coding skills for Solana Mobile (Seeker) dApps.
-
-- [solana-mobile-dev-skill](https://github.com/solana-mobile/solana-mobile-dev-skill) - Official Solana Mobile skills covering Mobile Wallet Adapter (setup, connection, transactions), `.skr` domain resolution, and Seeker Genesis Token verification for React Native Expo apps.
 - [seeker-skills](https://github.com/Sarthib7/seeker-skills) - End-to-end skills for building a Seeker dApp: scaffold + Android toolchain, UX conventions (one-tap approval, haptics, AMOLED, 120 Hz), USDC/SOL payments via MWA, Seed Vault for wallet developers, and dApp Store APK signing + publishing via `@solana-mobile/dapp-store-cli`.
+- [solana-mobile-dev-skill](https://github.com/solana-mobile/solana-mobile-dev-skill) - Official Solana Mobile skills covering Mobile Wallet Adapter (setup, connection, transactions), `.skr` domain resolution, and Seeker Genesis Token verification for React Native Expo apps.
 
 ## AI Agents
 


### PR DESCRIPTION
## Summary

  Adds a new `Mobile & Seeker` subsection under AI Coding Skills with two complementary entries:

  - [`solana-mobile/solana-mobile-dev-skill`](https://github.com/solana-mobile/solana-mobile-dev-skill) — Solana Mobile's official skill set covering Mobile
  Wallet Adapter (setup, connection, transactions), `.skr` domain resolution, and Seeker Genesis Token verification for React Native Expo apps.
  - [`Sarthib7/seeker-skills`](https://github.com/Sarthib7/seeker-skills) — End-to-end skills for the rest of the Seeker dApp lifecycle: scaffold + Android
  toolchain, Seeker-specific UX conventions (one-tap approval, haptics, AMOLED, 120 Hz), USDC/SOL payments via MWA, Seed Vault for wallet developers (with a
  boundary note routing dApp builders back to MWA), and dApp Store APK signing + publishing via `@solana-mobile/dapp-store-cli`.

  ## Why a new subsection

  Mobile/Seeker development has a distinct toolchain — MWA, the dApp Store, Seed Vault, and Seeker hardware constraints — that doesn't fit cleanly under
  General, DeFi, or Infrastructure. A dedicated subsection makes the category discoverable for devs building on Seeker. Currently only `solana-game-skill`
  mentions Solana Mobile in passing, and it sits under General. Per `CONTRIBUTING.md`: *"If your item doesn't fit existing categories, you may suggest a new
  one. Please explain why the new category is needed."*

  **Adding a new item**
  - [x] Related to AI and Solana development — both are Claude Code skills for Solana Mobile dApp development
  - [x] Added to an appropriate category — new `Mobile & Seeker` subsection proposed under AI Coding Skills, justification above
  - [x] Format `[name](link) - Brief description.` — both entries follow exactly
  - [x] One-sentence descriptions — each entry is a single sentence (information-dense, matching existing patterns like `helius-skill` and
  `magicblock-dev-skill`)
  - [x] Spelling and grammar checked

  **Quality standards**
  - [x] Actively maintained — both repos updated recently
  - [x] Documentation available — READMEs in both, plus per-skill `Use` / `Not` blocks and pitfall tables in `seeker-skills`
  - [x] Provides value to Solana developers — fills the gap between scaffolding a Solana Mobile app and shipping it to the dApp Store

  **What NOT to submit**
  - [x] No token promotion
  - [x] No paid promotion
  - [x] No vaporware — both are CC0 markdown skill sets, working today, installable via `cp -r` into `~/.claude/skills/`

  **Pull request process**
  - [x] Forked the repo (`Sarthib7/awesome-solana-ai`)
  - [x] Branched (`add-seeker-skills`)
  - [x] Changes scoped to `README.md` only (+8 lines, single commit)
  - [x] Clear PR description (this one)

  ## Notes

  The two skill sets are intentionally complementary, not overlapping: the official repo covers MWA + `.skr` + SGT; `seeker-skills` covers scaffold + UX +
  payments + Seed Vault audience boundary + dApp Store publishing. Together they walk an agent end-to-end from empty repo → signed APK → live dApp Store
  listing.

  `seeker-skills` is licensed CC0 to match this list.