### PR TITLE
Add depeg-skill under DeFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ AI coding skills that enhance developer productivity on Solana.
 ### DeFi
 
 - [clawpump-arbitrage-skill](https://clawpump.tech/arbitrage.md) - AI agent skill for multi-DEX arbitrage on Solana covering 11 DEX quote aggregation, roundtrip and bridge strategies, and ready-to-sign transaction bundle generation.
+- [depeg-skill](https://github.com/DepegOrg/claude-skill) - AI coding skill for the DEPEG protocol, wrapping pump.fun memecoins as 1:1 USDC-backed stablecoins with staking, 7-day reward boosters, and lock-period-boosted yield on Solana.
 - [dflow-phantom-connect-skill](https://github.com/DFlowProtocol/dflow_phantom-connect-skill) - Official DFlow + Phantom Connect skill for building full-stack, wallet-connected Solana apps with Phantom Connect SDKs, plus DFlow swaps, prediction market trading, and Proof KYC verification.
 - [dflow-skill](https://github.com/sendaifun/skills/tree/main/skills/dflow) - AI coding skill for DFlow trading protocol covering spot trading, prediction markets, Swap API, and WebSocket streaming on Solana.
 - [drift-skill](https://github.com/sendaifun/skills/tree/main/skills/drift) - AI coding skill for Drift Protocol SDK covering perpetual futures, spot trading, and DeFi applications on Solana.


### PR DESCRIPTION
Adds the DEPEG protocol skill to the DeFi section.

[DEPEG](https://depeg.app) is a Solana protocol that wraps every pump.fun memecoin with a 1:1 USDC-backed companion stablecoin. Trade fees from the underlying pump.fun bonding curve flow into the stablecoin vault as yield. Holders stake the stablecoin for lock-period-boosted rewards (1.0× → 6,975× across 8 tiers) and buy 7-day boosters paid in SOL.

The skill teaches an agent to derive every public PDA, decode the on-chain account layouts, build the user-facing instruction surface (swap USDC ↔ stablecoin, stake, claim, unstake, buy booster, launch pool), and parse the `DEPEG_PROTOCOL [depeg::*]` log format.

**Live**:
- Program: `Be3rdwxjwhoYFvRwm7j8jGKPctgHz2btsuoQSqWvvJzj` (mainnet + devnet)
- Web: https://depeg.app

**Companion packages**:
- npm: [`@depegprotocol/sdk`](https://www.npmjs.com/package/@depegprotocol/sdk)
- npm: [`@depegprotocol/mcp-server`](https://www.npmjs.com/package/@depegprotocol/mcp-server)

License: MIT. Actively maintained, working code today.