### PR TITLE
Add AIP (Agent Internet Protocol) to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ AI agents and autonomous systems built for Solana.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 - [MoonPay CLI](https://moonpay.com/agents) - AI agent CLI for token swaps, bridging, DCA, wallet management, fiat on/off-ramp, and prediction markets on Solana. Includes Claude Code skills for autonomous trading workflows.
+- [AIP - Agent Internet Protocol](https://aipagents.xyz) - W3C-conformant on-chain identity for autonomous agents on Solana via the did:aip DID method. Sovereign, globally unique agent identifiers anchored to program-derived addresses, with capability discovery and x402 payment-gated task execution. did:aip is under registration with the W3C did-extensions registry, backed by a live Devnet program and an open-source TypeScript resolver.
 
 ## Developer Tools
 


### PR DESCRIPTION
Adds AIP (Agent Internet Protocol) under AI Agents.

AIP is an open standard for autonomous agent identity on Solana. Agents get a
W3C-conformant DID (did:aip) anchored to a program-derived address: sovereign,
globally unique, and resolvable from the identifier alone with no central
registry.

Why it fits this list:

- Working code, usable today: registry program live on Solana Devnet
  (CgchXu2dRV3r9E1YjRhp4kbeLLtv1Xz61yoerJzp1Vbc), with an open-source
  TypeScript resolver and an end-to-end test.
- The did:aip method is under registration with the W3C did-extensions
  registry (w3c/did-extensions PR #704) and is being discussed as a Solana
  sRFC (solana-foundation/SRFCs #11).
- No token, no paid promotion. Open standard, MIT licensed.