### PR TITLE
Add jito-restaking-skill — NCNs, Vault SDK, and stake delegation on Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ AI coding skills that enhance developer productivity on Solana.
 - [Sentients](https://github.com/koshmade/sentients.wtf) - AI agents minting unique inscriptions on Solana. First AI Agent-Native Protocol with autonomous wallets and deterministic art generated from blockchain entropy.
 
 ### Infrastructure
-
+- [jito-restaking-skill](https://github.com/smile-XX/jito-restaking-skill/tree/SKILL) - AI coding skill for Jito Restaking covering NCNs, VRTs, vault operations, stake delegation, and restaking reward flows on Solana.
 - [agentic-gateway](https://github.com/alchemyplatform/skills/tree/main/skills/agentic-gateway) - Official Alchemy skill for accessing Solana and multi-chain blockchain APIs through wallet-based x402 flows, with SIWS support for Solana wallets.
 - [alchemy-api](https://github.com/alchemyplatform/skills/tree/main/skills/alchemy-api) - Official Alchemy skill for Solana RPC, DAS, Yellowstone gRPC, token prices, NFT data, and multi-chain blockchain development using an Alchemy API key.
 - [coingecko-skill](https://github.com/sendaifun/skills/tree/main/skills/coingecko) - AI coding skill for CoinGecko Solana API covering token prices, DEX pool data, OHLCV charts, and market analytics.


### PR DESCRIPTION
## Summary

Adds a new AI coding skill for Jito (Re)staking — one of Solana's core restaking protocols with no existing skill coverage in this repo.

## What this skill covers

- NCN (Node Consensus Network) lifecycle: initialization, warm-up, operation, maintenance
- Vault operations: create vaults, mint/burn VRTs, delegate stake
- Operator management: registration, opt-in, state tracking
- Stake delegation flow: deposit → delegate → cooldown → withdraw
- TypeScript SDK usage: `@jito-foundation/restaking-sdk` and `@jito-foundation/vault-sdk`
- Common error handling and devnet testing patterns

## Skill repo

https://github.com/smile-XX/jito-restaking-skill/tree/SKILL

## Checklist

- [x] Skill covers a protocol not yet listed in this repo
- [x] SKILL.md is in the skill repository root
- [x] Description added to README.md under the appropriate section
- [x] Links point to public repositories