### PR TITLE
Add Proxygate to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ AI agents and autonomous systems built for Solana.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 - [MoonPay CLI](https://moonpay.com/agents) - AI agent CLI for token swaps, bridging, DCA, wallet management, fiat on/off-ramp, and prediction markets on Solana. Includes Claude Code skills for autonomous trading workflows.
+- [Proxygate](https://proxygate.ai) - Curated marketplace of real-world data APIs for AI agents: connect once over MCP and call any listing (market data, crypto, weather, dev tools, and more) per request from one prepaid USDC balance on Solana, with seller keys injected server-side and a signed receipt per call.
 
 ## Developer Tools
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ AI agents and autonomous systems built for Solana.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 - [MoonPay CLI](https://moonpay.com/agents) - AI agent CLI for token swaps, bridging, DCA, wallet management, fiat on/off-ramp, and prediction markets on Solana. Includes Claude Code skills for autonomous trading workflows.
-- [Proxygate](https://proxygate.ai) - Curated marketplace of real-world data APIs for AI agents: connect once over MCP and call any listing (market data, crypto, weather, dev tools, and more) per request from one prepaid USDC balance on Solana, with seller keys injected server-side and a signed receipt per call.
+- [Proxygate](https://proxygate.ai) - Curated marketplace of real-world data APIs for AI agents: connect once (MCP, SDK, CLI, or REST API) and call any listing (market data, crypto, weather, dev tools, and more) per request from one prepaid USDC balance on Solana, with seller keys injected server-side and a signed receipt per call.
 
 ## Developer Tools
 


### PR DESCRIPTION
Adds **Proxygate** to the **AI Agents** category.

Proxygate is a curated marketplace of real-world data APIs built for AI agents. An agent connects once over MCP, then calls any listing (market data, crypto, weather, geocoding, dev tools, and more) per request from a single prepaid USDC balance on Solana. Settlement and escrow run on-chain, seller keys are injected server-side and never exposed, and every call returns a signed receipt.

- Website: https://proxygate.ai
- Remote MCP server: `https://gateway.proxygate.ai/mcp` (official MCP Registry: `ai.proxygate/mcp`)
- Closest peer already listed: OpenDexter (x402 marketplace of paid APIs for agents)

One entry added, existing format and category conventions followed. Working product, no token promotion.
