### PR TITLE
Add AgentFund to AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ AI agents and autonomous systems built for Solana.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 - [MoonPay CLI](https://moonpay.com/agents) - AI agent CLI for token swaps, bridging, DCA, wallet management, fiat on/off-ramp, and prediction markets on Solana. Includes Claude Code skills for autonomous trading workflows.
+- [AgentFund](https://agentfund.online) - Fundraising infrastructure for AI agents on Solana. Agents register on-chain identities, launch campaigns, donate via x402 (the payment is the auth), vote on milestone releases, and build on-chain reputation, with funds held in program-derived escrow until contributor votes clear. Live on devnet with real settled x402 USDC donations; integrates via TypeScript SDK, MCP server, or ACP manifest.
 
 ## Developer Tools
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ AI agents and autonomous systems built for Solana.
 - [OpenDexter](https://open.dexter.cash) - x402 search engine and payment gateway for AI agents. Search 5,000+ paid APIs, check pricing, and pay with automatic USDC settlement. Available as an [MCP server](https://open.dexter.cash/mcp) (no auth needed) or [npm package](https://www.npmjs.com/package/@dexterai/opendexter) (`npx @dexterai/opendexter install`).
 - [Blueprint Agentic Staking (Solentic)](https://github.com/mbrassey/solentic) - Native Solana staking infrastructure for AI agents with 18 MCP tools, 21 REST endpoints, and 13 A2A skills. Zero custody design — agents receive unsigned base64 transactions and sign client-side. Supports stake, unstake, withdraw, simulate, and verify operations with ~6% APY via Blueprint validator.
 - [MoonPay CLI](https://moonpay.com/agents) - AI agent CLI for token swaps, bridging, DCA, wallet management, fiat on/off-ramp, and prediction markets on Solana. Includes Claude Code skills for autonomous trading workflows.
-- [AgentFund](https://agentfund.online) - Fundraising infrastructure for AI agents on Solana. Agents register on-chain identities, launch campaigns, donate via x402 (the payment is the auth), vote on milestone releases, and build on-chain reputation, with funds held in program-derived escrow until contributor votes clear. Live on devnet with real settled x402 USDC donations; integrates via TypeScript SDK, MCP server, or ACP manifest.
+- [AgentFund](https://agentfund.online) - On-chain fundraising infrastructure for AI agents on Solana (devnet): register agent identities, launch campaigns, receive x402 USDC donations into program-derived escrow, and release funds only after contributor-weighted milestone votes clear.
 
 ## Developer Tools
 


### PR DESCRIPTION
AgentFund is fundraising infrastructure for AI agents on Solana: agents register on-chain identities, launch campaigns, donate via x402 (the payment itself is the auth, no API keys/OAuth), vote on milestone releases weighted by contribution, and build verifiable on-chain reputation. Escrowed funds sit in a program-derived account and release only after contributor votes clear; failed campaigns refund automatically.

Not a token — no token launch, no promotion of a token. Working code today: three Anchor programs live on Solana devnet, a public API with real-time Helius-webhook indexing, real settled x402 USDC donations (end-to-end, ~2.5s), and three integration paths for agents (TypeScript SDK, MCP server, ACP manifest).

Added one entry to the AI Agents section, format-matched to the neighboring SAID Protocol entry (also agent identity/reputation infra).

- Site: https://agentfund.online
- Repo: https://github.com/agentIgris/agentfund
- MCP server: https://github.com/agentIgris/agentfund/tree/main/mcp