### PR TITLE
Add Utilia Solana Preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ AI agents and autonomous systems built for Solana.
 AI-enhanced development tools for the Solana ecosystem.
 
 - [Solana Developer MCP](https://mcp.solana.com/) - Maintained by Solana. Solana MCP (Model Context Protocol) is a specialized AI assistant that integrates directly into AI-supported IDEs like Cursor and Windsurf (works with Claude CLI as well). Automatically queries the MCP server to provide accurate, up-to-date information from Solana and Anchor Framework documentation.
+- [Utilia Solana Preflight](https://utilia.ink) - Pay-per-call x402 API and MCP server for Solana transaction simulation, failure diagnostics, priority-fee estimates, and token-risk signals, payable in USDC without an account or API key.
 - [DFlow MCP Server](https://pond.dflow.net/build/mcp) - Unified spot + prediction market trading API with smart routing and low-failure execution; MCP connects AI tools to DFlow docs, APIs, and code recipes for accurate integrations on Solana.
 - [Deside MCP](https://github.com/DesideApp/deside-mcp) - Wallet-to-wallet messaging primitive for Solana agents via MCP, where agents authenticate with an Ed25519 keypair and send DMs addressed by pubkey.
 - [Phantom Connect SDK](https://docs.phantom.com) - Official Phantom Connect SDK documentation MCP server providing real-time API reference for building wallet-connected apps on Solana using `@phantom/react-sdk`, `@phantom/react-native-sdk`, and `@phantom/browser-sdk`.


### PR DESCRIPTION
## Summary

Adds Utilia Solana Preflight to the Infrastructure section.

Utilia is a live Solana-native x402 API and MCP service with six read-only tools for transaction simulation, failure diagnostics, priority-fee estimates, token-risk evidence, PDF-to-Markdown, and audio normalization. It requires no account or API key. Hosted MCP payments settle in USDC on Solana mainnet; explicit HTTP aliases also support Base settlement.

## Quality checks

- Live service and developer documentation: https://utilia.ink
- OpenAPI: https://api.utilia.ink/openapi.json
- Remote MCP: https://api.utilia.ink/mcp
- Public npm client: https://www.npmjs.com/package/utilia-solana-agent
- On-chain identity: https://8004market.io/agent/solana/mainnet-beta/1462
- Solana Foundation pay catalog validation: 5/5 paid routes plus the free health route in https://github.com/solana-foundation/pay-skills/pull/203

The submitted description follows the required one-line `[name](link) - Brief description.` format.